### PR TITLE
Patch about CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ I have often found myself paging across millions of log rows or massive non-norm
 <br/>
 <br/>
 
+####Download
+
+ - Bower
+	 - `bower install angular-paging#1.0.3`
+ - CDN
+	 - for test/debug : https://rawgit.com/brantwills/Angular-Paging/master/paging.js
+	 - for production : https://rawgit.com/brantwills/Angular-Paging/v1.0.3/paging.js
+<br/>
+<br/>
+
 ####Code Samples
 -------------
 [![alt text](https://raw.githubusercontent.com/brantwills/Angular-Paging/gh-pages/basicSample.png "Basic Sample")](http://brantwills.github.io/Angular-Paging/)

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -16,8 +16,8 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
-            "http://code.angularjs.org/1.4.3/angular.js",
-            "http://code.angularjs.org/1.4.3/angular-mocks.js",
+            "https://ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular.min.js",
+            "https://ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular-mocks.js",
             "paging.js",
             "test/paging.spec.js"
         ],


### PR DESCRIPTION
- README now contains a download section bower command and CDN url access
- Use CDN for Karma dependencies (angular.min.js, angular-mock.js)